### PR TITLE
Update cheatsheet.xml

### DIFF
--- a/jboss-forge-html5-archetype/src/main/resources/archetype-resources/cheatsheet.xml
+++ b/jboss-forge-html5-archetype/src/main/resources/archetype-resources/cheatsheet.xml
@@ -3,6 +3,7 @@
 #set( $symbol_escape = '\' )
 #set($packagePath=$package.replace(".","/"))
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual


### PR DESCRIPTION
Because of warning 
```
 No grammar constraints (DTD or XML Schema) referenced in the document.
```

in [this](https://dev-platform-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/central.itests/220/jdk=jdk1.9,label=fedora26/testReport/org.jboss.tools.central.test.ui.reddeer/ArchetypesTest%20no-configuration/org_jboss_tools_central_test_ui_reddeer_ArchetypesTest_no_configuration/) job run i propose this change based on [this](https://stackoverflow.com/questions/4551783/no-grammar-constraints-dtd-or-xml-schema-detected-for-the-document/22294554#22294554) suggestion.